### PR TITLE
remove unsigned/outdated version of repo binary

### DIFF
--- a/envsetup.sh
+++ b/envsetup.sh
@@ -1728,14 +1728,6 @@ check_bash_version && {
     done
 }
 
-# SWITCH TO A VERSION OF REPO THAT DOESN'T SPAM PROJECT NAMES
-pushd . >& /dev/null
-cd $(gettop)/.repo/repo
-[ `git remote -v | grep vanir | wc -l` -eq 0 ] && git remote add vanir http://www.emccann.net/repo
-git fetch vanir >& /dev/null
-git checkout vanir/master >& /dev/null
-popd >& /dev/null
-
 #rst (repo start helper), rup (repo upload helper)
 source $(gettop)/build/nukehawtness
 


### PR DESCRIPTION
Unless this version of repo is updated, it needs to be removed from envsetup as it's causing issues. It's out of date at the moment.
